### PR TITLE
Fix: compile errors on ubuntu 18.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,6 @@ matrix:
       services: docker
       env: DOCKER_IMAGE=ubuntu:18.04
     - os: osx
-      osx_image: xcode9.2
-      sudo: required
-      env: SWIFT_SNAPSHOT=4.0.3
-    - os: osx
       osx_image: xcode9.4
       sudo: required
       env: SWIFT_SNAPSHOT=4.1.2

--- a/Package@swift-4.0.swift
+++ b/Package@swift-4.0.swift
@@ -25,12 +25,12 @@ var targetDependencies: [Target.Dependency] = []
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 
     let CryptoLibUrl = "https://github.com/IBM-Swift/CommonCrypto.git"
-    let CryptoLibVersion: Package.Dependency.Requirement = from: "1.0.0"
+    let CryptoLibVersion: Package.Dependency.Requirement = .upToNextMajor(from: "1.0.0")
 
 #else
 
     let CryptoLibUrl = "https://github.com/IBM-Swift/OpenSSL.git"
-    let CryptoLibVersion: Package.Dependency.Requirement = from: "1.0.1"
+    let CryptoLibVersion: Package.Dependency.Requirement = .upToNextMajor(from: "1.0.1")
     targetDependencies.append(.byName(name: "OpenSSL"))
 
 #endif

--- a/Package@swift-4.1.swift
+++ b/Package@swift-4.1.swift
@@ -25,12 +25,12 @@ var targetDependencies: [Target.Dependency] = []
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 
     let CryptoLibUrl = "https://github.com/IBM-Swift/CommonCrypto.git"
-    let CryptoLibVersion: Package.Dependency.Requirement = from: "1.0.0"
+    let CryptoLibVersion: Package.Dependency.Requirement = .upToNextMajor(from: "1.0.0")
 
 #else
 
     let CryptoLibUrl = "https://github.com/IBM-Swift/OpenSSL.git"
-    let CryptoLibVersion: Package.Dependency.Requirement = from: "1.0.1"
+    let CryptoLibVersion: Package.Dependency.Requirement = .upToNextMajor(from: "1.0.1")
     targetDependencies.append(.byName(name: "OpenSSL"))
 
 #endif

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@
 
 A cross platform Swift implementation of Elliptic Curve Digital Signature Algorithm (ECDSA) and Elliptic Curve Integrated Encryption Scheme (ECIES). This allows you to sign, verify, encrypt and decrypt using elliptic curve keys.
 
+## Swift version
+
+The latest version of BlueECC requires **Swift 4.1** or later. You can download this version of the Swift binaries by following this [link](https://swift.org/download/). Compatibility with other Swift versions is not guaranteed.
+
 ## Usage
 
 #### Add dependencies
@@ -46,7 +50,7 @@ Add `CryptorECC` to your target's dependencies:
 import CryptorECC
 ```
 
-## Usage guide
+### Getting Started
 
 #### Elliptic curve private key
 

--- a/Sources/CryptorECC/ECAlgorithm.swift
+++ b/Sources/CryptorECC/ECAlgorithm.swift
@@ -26,7 +26,7 @@ import Foundation
 struct ECAlgorithm {
     #if os(Linux)
         typealias CC_LONG = size_t
-        let signingAlgorithm: UnsafePointer<EVP_MD>
+        let signingAlgorithm: OpaquePointer?
         let curve: Int32
         let hashEngine: (_ data: UnsafePointer<UInt8>, _ len: CC_LONG, _ md: UnsafeMutablePointer<UInt8>) -> UnsafeMutablePointer<UInt8>? = SHA256
         let hashLength: size_t = CC_LONG(SHA256_DIGEST_LENGTH)
@@ -37,54 +37,54 @@ struct ECAlgorithm {
         let hashLength: CC_LONG
     #endif
     let keySize: Int
-    enum Pid {
-        case p256, p384, p521
+    enum Pid: String {
+        case prime256v1, secp384r1, secp521r1
     }
     let id: Pid
     
     #if os(Linux)
     /// Secure Hash Algorithm 2 256-bit
-    static let p256 = ECAlgorithm(signingAlgorithm: EVP_sha256(),
+    static let p256 = ECAlgorithm(signingAlgorithm: .init(EVP_sha256()),
                                     curve: NID_X9_62_prime256v1,
                                     keySize: 65,
-                                    id: .p256)
+                                    id: .prime256v1)
     #else
     /// Secure Hash Algorithm 2 256-bit
     static let p256 = ECAlgorithm(signingAlgorithm: .ecdsaSignatureDigestX962SHA256,
                                     hashEngine: CC_SHA256,
                                     hashLength: CC_LONG(CC_SHA256_DIGEST_LENGTH),
                                     keySize: 65,
-                                    id: .p256)
+                                    id: .prime256v1)
     #endif
 
     #if os(Linux)
     /// Secure Hash Algorithm 2 384-bit
-    static let p384 = ECAlgorithm(signingAlgorithm: EVP_sha384(),
+    static let p384 = ECAlgorithm(signingAlgorithm: .init(EVP_sha384()),
                                       curve: NID_secp384r1,
                                       keySize: 97,
-                                      id: .p384)
+                                      id: .secp384r1)
     #else
     /// Secure Hash Algorithm 2 384-bit
     static let p384 = ECAlgorithm(signingAlgorithm: .ecdsaSignatureDigestX962SHA384,
                                     hashEngine: CC_SHA384,
                                     hashLength: CC_LONG(CC_SHA384_DIGEST_LENGTH),
                                     keySize: 97,
-                                    id: .p384)
+                                    id: .secp384r1)
     #endif
 
     #if os(Linux)
     /// Secure Hash Algorithm 512-bit
-    static let p521 = ECAlgorithm(signingAlgorithm: EVP_sha512(),
+    static let p521 = ECAlgorithm(signingAlgorithm: .init(EVP_sha512()),
                                       curve: NID_secp521r1,
                                       keySize: 133,
-                                      id: .p521)
+                                      id: .secp521r1)
     #else
     /// Secure Hash Algorithm 512-bit
     static let p521 = ECAlgorithm(signingAlgorithm: .ecdsaSignatureDigestX962SHA512,
                                     hashEngine: CC_SHA512,
                                     hashLength: CC_LONG(CC_SHA512_DIGEST_LENGTH),
                                     keySize: 133,
-                                    id: .p521)
+                                    id: .secp521r1)
     #endif
 
     // Select the ECAlgorithm based on the object identifier (OID) extracted from the EC key.

--- a/Sources/CryptorECC/ECDecryptable.swift
+++ b/Sources/CryptorECC/ECDecryptable.swift
@@ -65,15 +65,15 @@ extension Data {
         defer {
             EC_POINT_free(pubk_point)
         }
-        let pubk_bn = encryptedKey.withUnsafeBytes({ (pubk: UnsafePointer<UInt8>) -> UnsafeMutablePointer<BIGNUM> in
-            return BN_bin2bn(pubk, Int32(encryptedKey.count), nil)
+        encryptedKey.withUnsafeBytes({ (pubk: UnsafePointer<UInt8>) in
+            let pubk_bn = BN_bin2bn(pubk, Int32(encryptedKey.count), nil)
+            let pubk_bn_ctx = BN_CTX_new()
+            BN_CTX_start(pubk_bn_ctx)
+            EC_POINT_bn2point(ec_group, pubk_bn, pubk_point, pubk_bn_ctx)
+            BN_CTX_end(pubk_bn_ctx)
+            BN_CTX_free(pubk_bn_ctx)
+            BN_clear_free(pubk_bn)
         })
-        let pubk_bn_ctx = BN_CTX_new()
-        BN_CTX_start(pubk_bn_ctx)
-        EC_POINT_bn2point(ec_group, pubk_bn, pubk_point, pubk_bn_ctx)
-        BN_CTX_end(pubk_bn_ctx)
-        BN_CTX_free(pubk_bn_ctx)
-        BN_clear_free(pubk_bn)
 
         // calculate symmetric key
         ECDH_compute_key(symKey, skey_len, pubk_point, key.nativeKey, nil)

--- a/Sources/CryptorECC/ECDecryptable.swift
+++ b/Sources/CryptorECC/ECDecryptable.swift
@@ -50,6 +50,7 @@ extension Data {
         let decrypted = UnsafeMutablePointer<UInt8>.allocate(capacity: Int(encryptedData.count + 16))
         defer {
             // On completion deallocate the memory
+            EVP_CIPHER_CTX_reset_wrapper(rsaDecryptCtx)
             EVP_CIPHER_CTX_free_wrapper(rsaDecryptCtx)
             #if swift(>=4.1)
             symKey.deallocate()

--- a/Sources/CryptorECC/ECEncryptable.swift
+++ b/Sources/CryptorECC/ECEncryptable.swift
@@ -119,7 +119,7 @@ extension Data: ECEncryptable {
             encrypted.deallocate()
             #else
             tag.deallocate(capacity: 16)
-            encrypted.deallocate(capacity: data.count + 16)
+            encrypted.deallocate(capacity: self.count + 16)
             #endif
         }
         

--- a/Sources/CryptorECC/ECPrivateKey.swift
+++ b/Sources/CryptorECC/ECPrivateKey.swift
@@ -144,10 +144,11 @@ public class ECPrivateKey {
         } else {
             throw ECError.failedASN1Decoding
         }
+        let trimmedPubBytes = publicKeyData.drop(while: { $0 == 0x00})
         self.nativeKey =  try ECPrivateKey.bytesToNativeKey(privateKeyData: privateKeyData,
-                                                            publicKeyData: publicKeyData,
+                                                            publicKeyData: trimmedPubBytes,
                                                             algorithm: algorithm)
-        self.pubKeyBytes = publicKeyData
+        self.pubKeyBytes = trimmedPubBytes
     }
 
     /// Initialize an ECPrivateKey from a SEC1 `.der` file data.  
@@ -173,10 +174,11 @@ public class ECPrivateKey {
         else {
             throw ECError.failedASN1Decoding
         }
+        let trimmedPubBytes = publicKeyData.drop(while: { $0 == 0x00})
         self.nativeKey =  try ECPrivateKey.bytesToNativeKey(privateKeyData: privateKeyData,
-                                                            publicKeyData: publicKeyData,
+                                                            publicKeyData: trimmedPubBytes,
                                                             algorithm: algorithm)
-        self.pubKeyBytes = publicKeyData.drop(while: { $0 == 0x00})
+        self.pubKeyBytes = trimmedPubBytes
     }
     
     /// Initialize the `ECPublicKey`for this private key by extracting the public key bytes.
@@ -233,12 +235,11 @@ public class ECPrivateKey {
             }
             return ecKey
         #else
-            let keyData = publicKeyData.drop(while: { $0 == 0x00}) + privateKeyData
+            let keyData = publicKeyData + privateKeyData
             var error: Unmanaged<CFError>? = nil
             guard let secKey = SecKeyCreateWithData(keyData as CFData,
                                                     [kSecAttrKeyType: kSecAttrKeyTypeECSECPrimeRandom,
-                                                     kSecAttrKeyClass: kSecAttrKeyClassPrivate,
-                                                     kSecAttrKeySizeInBits: 256] as CFDictionary,
+                                                     kSecAttrKeyClass: kSecAttrKeyClassPrivate] as CFDictionary,
                                                     &error)
             else {
                 if let secError = error?.takeRetainedValue() {

--- a/Sources/CryptorECC/ECPrivateKey.swift
+++ b/Sources/CryptorECC/ECPrivateKey.swift
@@ -45,13 +45,14 @@ import OpenSSL
  */
 @available(OSX 10.13, *)
 public class ECPrivateKey {
+    /// The Elliptic curve this key was generated from.
+    public let curveId: String
     #if os(Linux)
         typealias NativeKey = OpaquePointer?
         deinit { EC_KEY_free(.make(optional: self.nativeKey)) }
     #else
         typealias NativeKey = SecKey
     #endif
-
     let nativeKey: NativeKey
     let algorithm: ECAlgorithm
     let pubKeyBytes: Data
@@ -119,6 +120,7 @@ public class ECPrivateKey {
             throw ECError.failedASN1Decoding
         }
         self.algorithm = try ECAlgorithm.objectToHashAlg(ObjectIdentifier: privateKeyID)
+        self.curveId = self.algorithm.id.rawValue
         guard case let ASN1.ASN1Element.bytes(data: privateOctest) = es[2] else {
             throw ECError.failedASN1Decoding
         }
@@ -165,6 +167,7 @@ public class ECPrivateKey {
             throw ECError.failedASN1Decoding
         }
         self.algorithm = try ECAlgorithm.objectToHashAlg(ObjectIdentifier: objectId)
+        self.curveId = self.algorithm.id.rawValue
         guard case let ASN1.ASN1Element.constructed(tag: _, elem: publicElement) = seq[3],
             case let ASN1.ASN1Element.bytes(data: publicKeyData) = publicElement
         else {
@@ -187,17 +190,17 @@ public class ECPrivateKey {
         //         OBJECT IDENTIFIER
         //         OBJECT IDENTIFIER
         //     BIT STRING (This is the `pubKeyBytes` added afterwards)
-        if self.algorithm.id == .p256 {
+        if self.algorithm.id == .prime256v1 {
             keyHeader = Data(bytes: [0x30, 0x59,
                                      0x30, 0x13,
                                      0x06, 0x07, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01,
                                      0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07, 0x03, 0x42])
-        } else if self.algorithm.id == .p384 {
+        } else if self.algorithm.id == .secp384r1 {
             keyHeader = Data(bytes: [0x30, 0x76,
                                      0x30, 0x10,
                                      0x06, 0x07, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01,
                                      0x06, 0x05, 0x2B, 0x81, 0x04, 0x00, 0x22, 0x03, 0x62])
-        } else if self.algorithm.id == .p521 {
+        } else if self.algorithm.id == .secp521r1 {
             keyHeader = Data(bytes: [0x30, 0x81, 0x9B,
                                      0x30, 0x10,
                                      0x06, 0x07, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01,

--- a/Sources/CryptorECC/ECPublicKey.swift
+++ b/Sources/CryptorECC/ECPublicKey.swift
@@ -140,8 +140,7 @@ public class ECPublicKey {
             var error: Unmanaged<CFError>? = nil
             guard let secKey = SecKeyCreateWithData(keyData as CFData,
                                                     [kSecAttrKeyType: kSecAttrKeyTypeECSECPrimeRandom,
-                                                     kSecAttrKeyClass: kSecAttrKeyClassPublic,
-                                                     kSecAttrKeySizeInBits: 256] as CFDictionary,
+                                                     kSecAttrKeyClass: kSecAttrKeyClassPublic] as CFDictionary,
                                                      &error)
             else {
                 if let secError = error?.takeRetainedValue() {

--- a/Sources/CryptorECC/ECPublicKey.swift
+++ b/Sources/CryptorECC/ECPublicKey.swift
@@ -47,6 +47,8 @@ import OpenSSL
  */
 @available(OSX 10.13, *)
 public class ECPublicKey {
+    /// The Elliptic curve this key was generated from.
+    public let curveId: String
     #if os(Linux)
     typealias NativeKey = OpaquePointer?
     let pubKeyBytes: Data
@@ -111,6 +113,7 @@ public class ECPublicKey {
             throw ECError.failedASN1Decoding
         }
         self.algorithm = try ECAlgorithm.objectToHashAlg(ObjectIdentifier: privateKeyID)
+        self.curveId = self.algorithm.id.rawValue
         let keyData = publicKeyData.drop(while: { $0 == 0x00})
         #if os(Linux)
             self.pubKeyBytes = keyData

--- a/Sources/CryptorECC/ECSignature.swift
+++ b/Sources/CryptorECC/ECSignature.swift
@@ -102,7 +102,7 @@ public struct ECSignature {
         }
     
         let rc = self.asn1.withUnsafeBytes({ (sig: UnsafePointer<UInt8>) -> Int32 in
-            return EVP_DigestVerifyFinal(md_ctx, sig, self.asn1.count)
+            return SSL_EVP_digestVerifyFinal_wrapper(md_ctx, sig, self.asn1.count)
         })
 
         return rc == 1


### PR DESCRIPTION
This pull request fixes the package.swift compile errors for swift 4.0 and 4.1
It also uses `SSL_EVP_digestVerifyFinal_wrapper` to fix compile error in ubuntu 18.04
Finally is fixes a compile error in deallocating memory for Swift 4.0