### PR TITLE
Update podspec to 1.2.1 release

### DIFF
--- a/BlueECC.podspec
+++ b/BlueECC.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name        = "BlueECC"
-  s.version     = "1.2.0"
+  s.version     = "1.2.1"
   s.summary     = "Swift cross-platform ECC crypto library using CommonCrypto/libcrypto via Package Manager."
   s.homepage    = "https://github.com/IBM-Swift/BlueECC"
   s.license     = { :type => "Apache License, Version 2.0" }


### PR DESCRIPTION
This pull request updates the podspec to point to the 1.2.1 release of BlueECC so that Cocoapods can use the latest version.