### PR TITLE
fix: Add tvOS and watchOS to available

### DIFF
--- a/BlueECC.podspec
+++ b/BlueECC.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name        = "BlueECC"
-  s.version     = "1.2.1"
+  s.version     = "1.2.3"
   s.summary     = "Swift cross-platform ECC crypto library using CommonCrypto/libcrypto via Package Manager."
   s.homepage    = "https://github.com/IBM-Swift/BlueECC"
   s.license     = { :type => "Apache License, Version 2.0" }

--- a/Sources/CryptorECC/ECDecryptable.swift
+++ b/Sources/CryptorECC/ECDecryptable.swift
@@ -22,7 +22,7 @@ import OpenSSL
 #endif
 
 /// Extensions for encrypting, decrypting or signing `Data` using the appropriate algorithm determined by the key's curve with the provided `ECPrivateKey` or `ECPublicKey`.
-@available(macOS 10.13, iOS 11, *)
+@available(macOS 10.13, iOS 11, watchOS 4.0, tvOS 11.0, *)
 extension Data {
     
     /// Decrypt the encrypted data using the provided `ECPrivateKey`.

--- a/Sources/CryptorECC/ECEncryptable.swift
+++ b/Sources/CryptorECC/ECEncryptable.swift
@@ -22,14 +22,14 @@ import OpenSSL
 #endif
 
 /// A protocol for encrypting an instance of some object to generate some encrypted data.
-@available(macOS 10.13, iOS 11, *)
+@available(macOS 10.13, iOS 11, watchOS 4.0, tvOS 11.0, *)
 protocol ECEncryptable {
     /// Encrypt the object using ECIES and produce some encrypted `Data`.
     func encrypt(with: ECPublicKey) throws -> Data
 }
 
 /// Extensions for encrypting or signing a `String` by converting it to UTF8 Data, then using the appropriate algorithm determined by the key's curve with the provided `ECPrivateKey` or `ECPublicKey`.
-@available(macOS 10.13, iOS 11, *)
+@available(macOS 10.13, iOS 11, watchOS 4.0, tvOS 11.0, *)
 extension String: ECEncryptable {
     
     /// UTF8 encode the String to Data and encrypt it using the `ECPublicKey`.
@@ -44,7 +44,7 @@ extension String: ECEncryptable {
 }
 
 /// Extension for signing `Data` with an `ECPrivateKey` and the algorithm determined by the key's curve.
-@available(macOS 10.13, iOS 11, *)
+@available(macOS 10.13, iOS 11, watchOS 4.0, tvOS 11.0, *)
 extension Data: ECEncryptable {
     
     /// Encrypt the data using the `ECPublicKey`.

--- a/Sources/CryptorECC/ECPrivateKey.swift
+++ b/Sources/CryptorECC/ECPrivateKey.swift
@@ -42,7 +42,7 @@ import OpenSSL
  let signature = "Hello world".sign(with: privateKey)
  ```
  */
-@available(macOS 10.13, iOS 11, *)
+@available(macOS 10.13, iOS 11, watchOS 4.0, tvOS 11.0, *)
 public class ECPrivateKey {
     /// A String description of the curve this key was generated from.
     public let curveId: String

--- a/Sources/CryptorECC/ECPublicKey.swift
+++ b/Sources/CryptorECC/ECPublicKey.swift
@@ -45,7 +45,7 @@ import OpenSSL
  let verified = signature.verify(plaintext: "Hello world", using: publicKey)
  ```
  */
-@available(macOS 10.13, iOS 11, *)
+@available(macOS 10.13, iOS 11, watchOS 4.0, tvOS 11.0, *)
 public class ECPublicKey {
     /// A String description of the curve this key was generated from.
     public let curveId: String

--- a/Sources/CryptorECC/ECSignable.swift
+++ b/Sources/CryptorECC/ECSignable.swift
@@ -22,13 +22,13 @@ import OpenSSL
 #endif
 
 /// A protocol for signing an instance of some object to generate an `ECSignature`.
-@available(macOS 10.13, iOS 11, *)
+@available(macOS 10.13, iOS 11, watchOS 4.0, tvOS 11.0, *)
 protocol ECSignable {
     /// Sign the object using ECDSA and produce an `ECSignature`.
     func sign(with: ECPrivateKey) throws -> ECSignature
 }
 
-@available(macOS 10.13, iOS 11, *)
+@available(macOS 10.13, iOS 11, watchOS 4.0, tvOS 11.0, *)
 extension String: ECSignable {
     /// UTF8 encode the String to Data and sign it using the `ECPrivateKey`.
     /// The Data is signed using ECDSA with either SHA256, SHA384 or SHA512, depending on the key's curve.
@@ -40,7 +40,7 @@ extension String: ECSignable {
     }
 }
 
-@available(macOS 10.13, iOS 11, *)
+@available(macOS 10.13, iOS 11, watchOS 4.0, tvOS 11.0, *)
 extension Data: ECSignable {
     /// Sign the plaintext data using the provided `ECPrivateKey`.
     /// The Data is signed using ECDSA with either SHA256, SHA384 or SHA512, depending on the key's curve.

--- a/Sources/CryptorECC/ECSignature.swift
+++ b/Sources/CryptorECC/ECSignature.swift
@@ -23,7 +23,7 @@ import OpenSSL
 
 /// The signature produced by applying an Elliptic Curve Digital Signature Algorithm to some Plaintext data.
 /// It consists of two binary unsigned integers, `r` and `s`.
-@available(macOS 10.13, iOS 11, *)
+@available(macOS 10.13, iOS 11, watchOS 4.0, tvOS 11.0, *)
 public struct ECSignature {
     
     // MARK: Signature Values

--- a/Sources/CryptorECC/EllipticCurve.swift
+++ b/Sources/CryptorECC/EllipticCurve.swift
@@ -22,7 +22,7 @@ import Foundation
 #endif
 
 /// An extensible list of elliptic curves supported by this repository.
-@available(macOS 10.13, iOS 11, *)
+@available(macOS 10.13, iOS 11, watchOS 4.0, tvOS 11.0, *)
 public struct EllipticCurve: Equatable, CustomStringConvertible {
     
     private let internalRepresentation: InternalRepresentation

--- a/Tests/CryptorECCTests/CryptorECCTests.swift
+++ b/Tests/CryptorECCTests/CryptorECCTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import CryptorECC
 
-@available(macOS 10.13, iOS 11, *)
+@available(macOS 10.13, iOS 11, watchOS 4.0, tvOS 11.0, *)
 final class CryptorECCTests: XCTestCase {
     static var allTests = [
             ("test_simpleCycle", test_simpleCycle),


### PR DESCRIPTION
## Description
This pull request adds watchOS 4.0, tvOS 11.0 to the `@available` checks in this repo. 
This allows the project to compile on those operating systems when building the project directly (E.g. through Carthage).