### PR TITLE
Enabling pattern matching on ECError

### DIFF
--- a/Sources/CryptorECC/ECError.swift
+++ b/Sources/CryptorECC/ECError.swift
@@ -69,4 +69,12 @@ public struct ECError: Error, Equatable {
     public static func == (lhs: ECError, rhs: ECError) -> Bool {
         return lhs.internalError == rhs.internalError
     }
+    
+    /// Function to enable pattern matching against generic Errors.
+    public static func ~= (lhs: ECError, rhs: Error) -> Bool {
+        guard let rhs = rhs as? ECError else {
+            return false
+        }
+        return lhs == rhs
+    }
 }


### PR DESCRIPTION
fixes issue #11. This pull request allows you to pattern match an ECError against a general error. 
This was added to SwiftJWT by the community in pr [45](https://github.com/IBM-Swift/Swift-JWT/pull/45) and is a nice little addition that we would like to bring here as well.