### PR TITLE
ci: Enable Xcode11 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,11 +47,10 @@ matrix:
     - os: osx
       osx_image: xcode10.2
       sudo: required
-# Pending Travis Xcode 11 image
-#    - os: osx
-#      osx_image: xcode11
-#      sudo: required
-#      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
+    - os: osx
+      osx_image: xcode11
+      sudo: required
+      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git

--- a/Sources/CryptorECC/ECPublicKey.swift
+++ b/Sources/CryptorECC/ECPublicKey.swift
@@ -82,7 +82,7 @@ public class ECPublicKey {
      */
     public convenience init(key: String) throws {
         let strippedKey = String(key.filter { !" \n\t\r".contains($0) })
-        var pemComponents = strippedKey.components(separatedBy: "-----")
+        let pemComponents = strippedKey.components(separatedBy: "-----")
         guard pemComponents.count == 5 else {
             throw ECError.invalidPEMString
         }


### PR DESCRIPTION
Travis recently published an `xcode11` macOS image.  This enables the macOS 5.1 CI testing.
Also resolve a compile warning.